### PR TITLE
Adjust definition of midplane subsets

### DIFF
--- a/src/SOLPS2IMAS.jl
+++ b/src/SOLPS2IMAS.jl
@@ -411,7 +411,7 @@ Returns true if boundary_ind of a cell at ix, iy is on outer midplane
 """
 function is_outer_midplane(; ix, iy, jxa, boundary_ind, topcut, kwargs...)
     # Note: USING CONVENTION to mark bottom edge of the midplane cell as midplane
-    return ix == jxa && iy > topcut + 1 && boundary_ind == 1
+    return ix == jxa && boundary_ind == 1
 end
 
 
@@ -422,7 +422,7 @@ Returns true if boundary_ind of a cell at ix, iy is on outer midplane
 """
 function is_inner_midplane(; ix, iy, jxi, boundary_ind, topcut, kwargs...)
     # Note: USING CONVENTION to mark bottom edge of the midplane cell as midplane
-    return ix == jxi && iy > topcut + 1 && boundary_ind == 1
+    return ix == jxi && boundary_ind == 1
 end
 
 

--- a/src/SOLPS2IMAS.jl
+++ b/src/SOLPS2IMAS.jl
@@ -400,7 +400,7 @@ end
 Returns true if boundary_ind of a cell at ix, iy is on outer throat
 """
 function is_inner_throat(; ix, iy, boundary_ind, topcut, leftcut, kwargs...)
-    return topcut + 1 < iy && ix == leftcut + 2 && boundary_ind == 2
+    return topcut + 1 < iy && ix == leftcut + 2 && boundary_ind == 4
 end
 
 

--- a/src/SOLPS2IMAS.jl
+++ b/src/SOLPS2IMAS.jl
@@ -411,7 +411,7 @@ Returns true if boundary_ind of a cell at ix, iy is on outer midplane
 """
 function is_outer_midplane(; ix, iy, jxa, boundary_ind, topcut, kwargs...)
     # Note: USING CONVENTION to mark bottom edge of the midplane cell as midplane
-    return ix == jxa && boundary_ind == 1
+    return ix == jxa && boundary_ind == 2
 end
 
 
@@ -422,7 +422,7 @@ Returns true if boundary_ind of a cell at ix, iy is on outer midplane
 """
 function is_inner_midplane(; ix, iy, jxi, boundary_ind, topcut, kwargs...)
     # Note: USING CONVENTION to mark bottom edge of the midplane cell as midplane
-    return ix == jxi && boundary_ind == 1
+    return ix == jxi && boundary_ind == 4
 end
 
 


### PR DESCRIPTION
- They should include inside and outside the separatrix
- It's the throat ones that should respect topcut and only sample the SOL, because this is where the mesh wraps around on itself.
- At the midplane, the slice through the rectangular array is continously connected in real space, so topcut doesn't correspond to a discontinuity that needs treatment.