### PR TITLE
gsdec is keyword arg with default populated

### DIFF
--- a/src/SOLPS2IMAS.jl
+++ b/src/SOLPS2IMAS.jl
@@ -17,6 +17,8 @@ include("subset_id.jl")
 
 include("solps_mesh_tools.jl")
 
+default_gsdesc = "$(@__DIR__)/default_grid_space_description.yml"
+
 """
     dict2prop!(obj, dict)
 
@@ -86,7 +88,13 @@ output file (either b2time or b2fstate) and a grid_ggd
 description in the form of a Dict or filename to equivalent
 YAML file. Returns data in OMAS.dd datastructure.
 """
-function solps2imas(b2gmtry, b2output, gsdesc, b2mn=nothing; load_bb=false)
+function solps2imas(
+    b2gmtry,
+    b2output;
+    gsdesc=default_gsdesc,
+    b2mn=nothing,
+    load_bb=false,
+)
     # Initialize an empty OMAS data structre
     ids = OMAS.dd()
 

--- a/src/default_grid_space_description.yml
+++ b/src/default_grid_space_description.yml
@@ -1,15 +1,15 @@
 identifier:                                                       # grid_ggd[#].Identifier properties
-  name: Sven                                                        
+  name: Default                                                       
   index: 1
-  description: This is a grid
+  description: This is a Single Null Grid GGD 
 space:
   1:                                                              # space_number
     identifier:                                                   # grid_ggd[it].space[#].identifier properties
-      name: linear
+      name: Linear
       index: 1
-      description: Linear
+      description: This is a linear space
     geometry_type:                                                # grid_dd[#].space[#].geometry_type properties
-      name:  "standard"                                           
+      name:  Standard                                           
       index:  0                                                   # 0: standard, 1:Fourier, >1: Fourier with periodicity
       description:  "trying to hold a b2/solps mesh here"         # Verbose descripition of space
     coordinates_type:  [4, 3]                                     # r, z

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -143,12 +143,11 @@ if args["solps2imas"]
     @testset "Test solps2imas() (overall workflow)" begin
         b2gmtry = "$(@__DIR__)/../samples/b2fgmtry"
         b2output = "$(@__DIR__)/../samples/b2time.nc"
-        gsdesc = "$(@__DIR__)/../samples/gridspacedesc.yml"
         b2mn = "$(@__DIR__)/../samples/b2mn.dat"
         b2t = SOLPS2IMAS.read_b2_output(b2output)
         nx = b2t["dim"]["nx"]
         print("solps2imas() time: ")
-        @time dd = SOLPS2IMAS.solps2imas(b2gmtry, b2output, gsdesc, b2mn)
+        @time dd = SOLPS2IMAS.solps2imas(b2gmtry, b2output; b2mn=b2mn)
         # Check time stamp 3 at iy=4, ix=5
         it = 3
         iy = 4


### PR DESCRIPTION
Argument gsdesc of solps2imas function has been made a keyword argument now with default value given as
src/default_grid_space_description.yml. Now, the user can skip providing this file and rely on code defaults for most of the use cases. This commit resovles
https://github.com/ProjectTorreyPines/SD4SOLPS.jl/issues/33

Note, that SD4SOLPS.jl requires some changes now.