### PR TITLE
Fix jxi tag and don't force b2mn jxa,jxi to int

### DIFF
--- a/src/SOLPS2IMAS.jl
+++ b/src/SOLPS2IMAS.jl
@@ -105,10 +105,10 @@ function solps2imas(
     if !isnothing(b2mn)
         mn = read_b2mn_output(b2mn)
         if "b2mwti_jxa" ∈ keys(mn)
-            jxa = Int(mn["b2mwti_jxa"])
+            jxa = mn["b2mwti_jxa"]
         end
         if "b2mwti_jxi" ∈ keys(mn)
-            jxi = Int(mn["b2mwti_jxa"])
+            jxi = mn["b2mwti_jxi"]
         end
     end
 


### PR DESCRIPTION
- Had jxa = jxa and jxi = jxa  (this part is definitely legit)
- Type of these things should now be set appropriately by parser; should trust parser and not force types (do you agree with this? Or should we have redundant type forcing to make sure solps2imas() will work?)