### PR TITLE
Fix reading mag field data from b2fgmtry, on by default, add test

### DIFF
--- a/src/SOLPS2IMAS.jl
+++ b/src/SOLPS2IMAS.jl
@@ -195,7 +195,7 @@ function solps2imas(
     fort::Tuple{String, String, String}=("", "", ""),
     fort_tol::Float64=1e-6,
     b2_parameters::Tuple{String, String, String, String}=("", "", "", ""),
-    load_bb::Bool=false,
+    load_bb::Bool=true,
 )::IMASDD.dd
     # Initialize an empty IMAS data structre
     ids = IMASDD.dd()
@@ -765,9 +765,9 @@ function solps2imas(
             b_z.grid_index =
                 b_r.grid_index = b_t.grid_index = gsdesc["identifier"]["index"]
             b_z.grid_subset_index = b_r.grid_subset_index = b_t.grid_subset_index = 5
-            resize!(b_z.values, ncell)
-            resize!(b_r.values, ncell)
-            resize!(b_t.values, ncell)
+            b_z.values = zeros(ncell)
+            b_r.values = zeros(ncell)
+            b_t.values = zeros(ncell)
             for iy ∈ 1:ny
                 for ix ∈ 1:nx
                     ic::Int = (iy - 1) * nx + ix

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -159,7 +159,7 @@ if args["solps2imas"]
         b2t = SOLPS2IMAS.read_b2_output(b2output)
         nx = b2t["dim"]["nx"]
         print("solps2imas() time: ")
-        @time dd = SOLPS2IMAS.solps2imas(b2gmtry, b2output; b2mn=b2mn)
+        @time dd = SOLPS2IMAS.solps2imas(b2gmtry, b2output; b2mn=b2mn, load_bb=false)
         # Check time stamp 3 at iy=4, ix=5
         it = 3
         iy = 4
@@ -211,6 +211,15 @@ if args["solps2imas"]
         @test Set(brute_force_pfrcut_list) == Set(subset_pfrcut_element_list)
         @test Set(brute_force_corebnd_list) == Set(subset_corebnd_element_list)
         @test Set(brute_force_separatrix_list) == Set(subset_separatrix_element_list)
+
+        # Test loading of magnetic field data from b2fgmtry to equilibrium IDS
+        @time ddbb = SOLPS2IMAS.solps2imas(b2gmtry, b2output; b2mn=b2mn, load_bb=true)
+        btor = ddbb.equilibrium.time_slice[1].ggd[1].b_field_tor[1].values
+        bz = ddbb.equilibrium.time_slice[1].ggd[1].b_field_z[1].values
+        br = ddbb.equilibrium.time_slice[1].ggd[1].b_field_r[1].values
+        @test length(btor) == (nx * ny)
+        @test length(bz) == length(btor)
+        @test length(br) == length(bz)
     end
 end
 


### PR DESCRIPTION
- Fixed bug in how magnetic field data from b2fgmtry were added to the IDS
- Turned on the load_bb option by default
- Added tests for cases with and without bb data being added